### PR TITLE
Refining learning path

### DIFF
--- a/docker-mastery-multitrack/02-language-quickstart/java/.dockerignore
+++ b/docker-mastery-multitrack/02-language-quickstart/java/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.mvn/
+*.iml
+.idea/
+.git/
+.gitignore
+README.md
+Dockerfile
+docker-compose.yml
+.dockerignore
+.DS_Store

--- a/docker-mastery-multitrack/02-language-quickstart/java/Dockerfile
+++ b/docker-mastery-multitrack/02-language-quickstart/java/Dockerfile
@@ -21,6 +21,11 @@ RUN mvn clean package -DskipTests
 # Runtime stage - smaller image
 FROM eclipse-temurin:17-jre-jammy
 
+# Install curl for health checks
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user for security
 # UID 1000 is standard
 ARG UID=1000

--- a/docker-mastery-multitrack/02-language-quickstart/java/Dockerfile
+++ b/docker-mastery-multitrack/02-language-quickstart/java/Dockerfile
@@ -1,0 +1,51 @@
+# Production Dockerfile for Java Task API
+# Multi-stage build for optimized image size
+
+# Build stage - using Maven image to avoid wrapper dependencies
+FROM maven:3.9-eclipse-temurin-17 AS builder
+
+WORKDIR /app
+
+# Copy configuration first for better caching
+COPY pom.xml .
+
+# Download dependencies (cached layer)
+RUN mvn dependency:go-offline
+
+# Copy source code
+COPY src ./src
+
+# Build the application
+RUN mvn clean package -DskipTests
+
+# Runtime stage - smaller image
+FROM eclipse-temurin:17-jre-jammy
+
+# Create non-root user for security
+# UID 1000 is standard
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -r -g ${GID} appgroup && \
+    useradd -r -g appgroup -u ${UID} appuser
+
+# Set working directory
+WORKDIR /app
+
+# Copy JAR from builder stage
+COPY --from=builder /app/target/*.jar app.jar
+
+# Change ownership to non-root user
+RUN chown -R appuser:appgroup /app
+
+# Switch to non-root user
+USER appuser
+
+# Expose the port
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+  CMD curl -f http://localhost:8080/health || exit 1
+
+# Run the application
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-mastery-multitrack/02-language-quickstart/java/docker-compose.yml
+++ b/docker-mastery-multitrack/02-language-quickstart/java/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  task-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: task-api-java
+    ports:
+      - "8080:8080"
+    environment:
+      - SERVER_PORT=8080
+      - MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=health,info,metrics
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 40s
+    networks:
+      - dev-network
+
+networks:
+  dev-network:

--- a/docker-mastery-multitrack/02-language-quickstart/java/docker-compose.yml
+++ b/docker-mastery-multitrack/02-language-quickstart/java/docker-compose.yml
@@ -1,10 +1,13 @@
-version: '3.8'
+version: "3.8"
 
 services:
   task-api:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     container_name: task-api-java
     ports:
       - "8080:8080"

--- a/docker-mastery-multitrack/02-language-quickstart/java/java-quickstart.md
+++ b/docker-mastery-multitrack/02-language-quickstart/java/java-quickstart.md
@@ -438,30 +438,35 @@ curl http://localhost:8080/health
 Create `Dockerfile`:
 
 ```dockerfile
-# Multi-stage build for optimized Java containers
-FROM eclipse-temurin:17-jdk AS builder
+# Production Dockerfile for Java Task API
+# Multi-stage build for optimized image size
 
-# Set working directory
+# Build stage - using Maven image to avoid wrapper dependencies
+FROM maven:3.9-eclipse-temurin-17 AS builder
+
 WORKDIR /app
 
-# Copy Maven wrapper and pom.xml
-COPY .mvn/ .mvn/
-COPY mvnw pom.xml ./
+# Copy configuration first for better caching
+COPY pom.xml .
 
 # Download dependencies (cached layer)
-RUN ./mvnw dependency:resolve
+RUN mvn dependency:go-offline
 
 # Copy source code
 COPY src ./src
 
 # Build the application
-RUN ./mvnw clean package -DskipTests
+RUN mvn clean package -DskipTests
 
 # Runtime stage - smaller image
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:17-jre-jammy
 
 # Create non-root user for security
-RUN groupadd -r appgroup && useradd -r -g appgroup appuser
+# UID 1000 is standard
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -r -g ${GID} appgroup && \
+    useradd -r -g appgroup -u ${UID} appuser
 
 # Set working directory
 WORKDIR /app
@@ -499,7 +504,9 @@ target/
 .gitignore
 README.md
 Dockerfile
+docker-compose.yml
 .dockerignore
+.DS_Store
 ```
 
 ### Build and Run Container

--- a/docker-mastery-multitrack/02-language-quickstart/java/java-quickstart.md
+++ b/docker-mastery-multitrack/02-language-quickstart/java/java-quickstart.md
@@ -461,6 +461,11 @@ RUN mvn clean package -DskipTests
 # Runtime stage - smaller image
 FROM eclipse-temurin:17-jre-jammy
 
+# Install curl for health checks
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user for security
 # UID 1000 is standard
 ARG UID=1000

--- a/docker-mastery-multitrack/02-language-quickstart/python/Dockerfile
+++ b/docker-mastery-multitrack/02-language-quickstart/python/Dockerfile
@@ -11,8 +11,12 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd -r fastapi && useradd -r -g fastapi -u 1000 fastapi
+# Create non-root user with configurable UID/GID
+# Default to 1000 but allow override for different systems
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -r -g ${GID} fastapi && \
+    useradd -r -g fastapi -u ${UID} fastapi
 
 # Create app directory
 WORKDIR /app

--- a/docker-mastery-multitrack/02-language-quickstart/python/Dockerfile.dev
+++ b/docker-mastery-multitrack/02-language-quickstart/python/Dockerfile.dev
@@ -11,8 +11,11 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd -r fastapi && useradd -r -g fastapi -u 1000 fastapi
+# Create non-root user with configurable UID/GID
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -r -g ${GID} fastapi && \
+    useradd -r -g fastapi -u ${UID} fastapi
 
 WORKDIR /app
 

--- a/docker-mastery-multitrack/02-language-quickstart/python/docker-compose.yml
+++ b/docker-mastery-multitrack/02-language-quickstart/python/docker-compose.yml
@@ -3,9 +3,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+      args:
+        # Pass host UID/GID to avoid permission issues
+        # Use: UID=$(id -u) GID=$(id -g) docker-compose up
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     volumes:
-      # Hot reload source code
+      # Hot reload source code (WARNING: bind mount permission issues possible!)
       - ./src:/app/src:cached
+      # Named volume for cache (no permission issues)
+      - python-cache:/app/.cache
     ports:
       - "8080:8080"
     environment:
@@ -25,6 +32,9 @@ services:
   #     - "5432:5432"
   #   networks:
   #     - dev-network
+
+volumes:
+  python-cache: # Docker-managed volume, no permission issues
 
 networks:
   dev-network:

--- a/docker-mastery-multitrack/02-language-quickstart/rust/Dockerfile
+++ b/docker-mastery-multitrack/02-language-quickstart/rust/Dockerfile
@@ -29,8 +29,10 @@ FROM alpine:3.18
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates curl
 
-# Create non-root user
-RUN addgroup -g 1000 rust && adduser -D -s /bin/sh -u 1000 -G rust rust
+# Create non-root user with configurable UID/GID
+ARG UID=1000
+ARG GID=1000
+RUN addgroup -g ${GID} rust && adduser -D -s /bin/sh -u ${UID} -G rust rust
 
 # Create app directory
 WORKDIR /app

--- a/docker-mastery-multitrack/02-language-quickstart/rust/rust-quickstart.md
+++ b/docker-mastery-multitrack/02-language-quickstart/rust/rust-quickstart.md
@@ -466,6 +466,26 @@ pub async fn health_check() -> Result<HttpResponse> {
 }
 ```
 
+## ⚠️ Important: Permission Issues Warning
+
+**Before building**: Our Dockerfile creates a user with UID 1000, but your host user might be different!
+
+```bash
+# Check your UID (might not be 1000!)
+id -u
+# Mac users: often 501
+# Enterprise Linux: often 10000+
+```
+
+**If you plan to use bind mounts**, build with your actual UID:
+
+```bash
+# Build with your host UID/GID to avoid permission issues
+docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t task-api-rust .
+```
+
+📖 **See**: [Complete Volumes & Permissions Guide](../../common-resources/VOLUMES_AND_PERMISSIONS_GUIDE.md) for details.
+
 ## 🐳 Rust Docker Patterns
 
 ### Production Dockerfile (Multi-stage)

--- a/docker-mastery-multitrack/common-resources/DOCKER_EMERGENCY_GUIDE.md
+++ b/docker-mastery-multitrack/common-resources/DOCKER_EMERGENCY_GUIDE.md
@@ -114,6 +114,8 @@ DATABASE_URL=postgresql://postgres:5432/db
 
 ## 💾 Volume & Permission Issues
 
+**📖 See also: [Complete Volumes & Permissions Guide](./VOLUMES_AND_PERMISSIONS_GUIDE.md)**
+
 ### "Permission Denied" Solutions
 
 ```bash

--- a/docker-mastery-multitrack/common-resources/VOLUMES_AND_PERMISSIONS_GUIDE.md
+++ b/docker-mastery-multitrack/common-resources/VOLUMES_AND_PERMISSIONS_GUIDE.md
@@ -1,0 +1,278 @@
+# Docker Volumes & Permissions Guide 🔐
+
+> **The #1 source of Docker frustration: Permission Denied errors!**
+
+## 🚨 The Problem Your Friend Spotted
+
+**"das -u 1000:1000 ist nicht zwingend richtig"** - Your friend is 100% correct!
+
+Hardcoding UID/GID to 1000 is a **common Docker anti-pattern** that breaks on:
+
+- macOS (first user is often 501)
+- Enterprise Linux (UIDs often start at 10000+)
+- Multi-user systems (could be any UID)
+
+## 📚 Understanding Volumes
+
+### What Are Volumes?
+
+Volumes are Docker's solution for **persistent data storage**. Without them, ALL container data disappears when the container stops!
+
+### Three Types of Storage
+
+#### 1. Named Volumes (Best for Databases)
+
+```yaml
+volumes:
+  postgres_data: # Docker manages this
+
+services:
+  postgres:
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+```
+
+**Pros:**
+
+- Docker handles permissions automatically
+- Data survives container removal
+- Easy backup/restore
+
+**Cons:**
+
+- Not directly editable from host
+- Need docker commands to inspect
+
+#### 2. Bind Mounts (Development Only!)
+
+```yaml
+services:
+  api:
+    volumes:
+      - ./src:/app/src # Maps host directory
+```
+
+**Pros:**
+
+- Direct file editing from host
+- Hot reload for development
+
+**Cons:**
+
+- **PERMISSION NIGHTMARES!**
+- UID/GID must match exactly
+- Different behavior across OS
+
+#### 3. tmpfs Mounts (RAM Storage)
+
+```yaml
+services:
+  api:
+    tmpfs:
+      - /tmp/cache
+```
+
+**Pros:**
+
+- Super fast (RAM)
+- Automatically cleaned
+
+**Cons:**
+
+- Data lost on restart
+- Limited by RAM
+
+## 🔥 The UID/GID Permission Problem
+
+### Why It Happens
+
+1. **Container Process**: Runs as UID 1000 (hardcoded)
+2. **Your Host**: You might be UID 501 (Mac) or 1001 (Linux)
+3. **Bind Mount**: Files owned by 501, container can't write (needs 1000)
+4. **Result**: Permission Denied! 😱
+
+### Real Example
+
+```bash
+# On Mac
+$ id -u
+501
+
+# In Dockerfile (WRONG!)
+RUN useradd -u 1000 appuser
+
+# Result when using bind mount
+docker run -v ./data:/app/data myapp
+> Error: Permission denied: /app/data/file.txt
+```
+
+## ✅ The Solutions
+
+### Solution 1: Dynamic UID/GID (Recommended)
+
+```dockerfile
+# Dockerfile
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g ${GID} appuser && \
+    useradd -u ${UID} -g appuser appuser
+```
+
+```yaml
+# docker-compose.yml
+services:
+  api:
+    build:
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+```
+
+```bash
+# Run with your actual UID/GID
+UID=$(id -u) GID=$(id -g) docker-compose up
+```
+
+### Solution 2: Use Named Volumes (Production)
+
+```yaml
+# No permission issues!
+volumes:
+  app_data:
+
+services:
+  api:
+    volumes:
+      - app_data:/app/data # Docker manages permissions
+```
+
+### Solution 3: Run as Root (NEVER in Production!)
+
+```dockerfile
+# Only for local debugging
+USER root  # Security risk!
+```
+
+### Solution 4: Fix Permissions at Runtime
+
+```dockerfile
+# entrypoint.sh
+#!/bin/sh
+# Fix permissions on startup (slow!)
+chown -R appuser:appuser /app/data
+exec "$@"
+```
+
+## 🎯 Best Practices
+
+### Development
+
+```yaml
+services:
+  api:
+    build:
+      args:
+        # Match host user
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
+    volumes:
+      # Code as read-only bind mount
+      - ./src:/app/src:ro
+      # Cache in named volume
+      - cache:/app/.cache
+```
+
+### Production
+
+```yaml
+services:
+  api:
+    # No bind mounts!
+    volumes:
+      # Only named volumes
+      - app_data:/app/data
+      - app_logs:/app/logs
+```
+
+## 🐛 Debugging Permission Issues
+
+### Check UIDs
+
+```bash
+# Host UID
+$ id -u
+501
+
+# Container UID
+$ docker exec container_name id
+uid=1000(appuser) gid=1000(appuser)
+
+# File ownership
+$ docker exec container_name ls -la /app/data
+drwxr-xr-x 2 501 501 4096  # Owned by host user!
+```
+
+### Quick Fixes
+
+```bash
+# Fix in container (temporary)
+docker exec -u root container_name chown -R 1000:1000 /app/data
+
+# Fix on host (permanent)
+sudo chown -R $(id -u):$(id -g) ./data
+
+# Nuclear option: world-writable (INSECURE!)
+chmod 777 ./data  # Never do this!
+```
+
+## 📋 Checklist
+
+Before using volumes:
+
+- [ ] **Know your UID**: Run `id -u` on host
+- [ ] **Use build args**: Pass UID/GID to Dockerfile
+- [ ] **Prefer named volumes**: For databases and production
+- [ ] **Bind mounts read-only**: Use `:ro` flag when possible
+- [ ] **Test on target OS**: Mac/Linux/Windows behave differently
+- [ ] **Document requirements**: Tell users about UID/GID needs
+
+## 🚀 Example: Fixing Our Python App
+
+### Before (Broken)
+
+```dockerfile
+# Hardcoded UID - breaks for many users!
+RUN useradd -u 1000 fastapi
+```
+
+### After (Fixed)
+
+```dockerfile
+# Flexible UID/GID
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g ${GID} fastapi && \
+    useradd -u ${UID} -g fastapi fastapi
+```
+
+### Usage
+
+```bash
+# Build with your UID
+docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t myapp .
+
+# Or with docker-compose
+UID=$(id -u) GID=$(id -g) docker-compose up
+```
+
+## 🎓 Key Takeaways
+
+1. **Never hardcode UID 1000** - It's not universal
+2. **Named volumes > Bind mounts** for production
+3. **Pass UID/GID as build args** for flexibility
+4. **Test on different systems** - Mac vs Linux matters
+5. **Document permission requirements** clearly
+
+---
+
+**Remember**: Permission issues are THE most common Docker problem. Get this right and save hours of debugging!


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Highlights**
> 
> - Adds production-grade Java setup: `Dockerfile`, `.dockerignore`, and `docker-compose.yml` with health checks and non-root user
> - Enables configurable UID/GID in Python and Rust `Dockerfile`s; Python dev compose now passes `UID/GID` and adds a `python-cache` volume
> - Expands documentation: updates Java/Python/Rust quickstarts with permission warnings; adds `04-docker-compose/01-compose-basics.md` content on volumes, service discovery, health checks; introduces `common-resources/VOLUMES_AND_PERMISSIONS_GUIDE.md` and references it in `DOCKER_EMERGENCY_GUIDE.md`
> 
> **Key changes**
> 
> - Java: switch to Maven builder, `eclipse-temurin:17-jre-jammy`, curl-based healthcheck, non-root user via build args
> - Python: `Dockerfile`/`Dockerfile.dev` accept `UID/GID`; compose passes args and mounts named cache volume
> - Rust: runtime user created via `UID/GID` build args
> - Docs: emphasize avoiding hardcoded UID 1000, prefer named volumes over bind mounts, and provide concrete Compose patterns
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69916baf82dcec8b783d1d2326a76ddad2333b35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->