### PR TITLE
Align module 02 quickstarts with sources and container workflows

### DIFF
--- a/docker-mastery-multitrack/02-language-quickstart/java/Dockerfile
+++ b/docker-mastery-multitrack/02-language-quickstart/java/Dockerfile
@@ -26,12 +26,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user for security
-# UID 1000 is standard
+# Create non-root user for security (reuse host GID if it already exists — avoids failures on some macOS hosts)
 ARG UID=1000
 ARG GID=1000
-RUN groupadd -r -g ${GID} appgroup && \
-    useradd -r -g appgroup -u ${UID} appuser
+RUN set -eux; \
+    if getent group "${GID}" >/dev/null 2>&1; then \
+      EXISTING="$(getent group "${GID}" | cut -d: -f1)"; \
+      useradd -r -g "${EXISTING}" -u "${UID}" appuser; \
+    else \
+      groupadd -r -g "${GID}" appgroup; \
+      useradd -r -g appgroup -u "${UID}" appuser; \
+    fi
 
 # Set working directory
 WORKDIR /app
@@ -40,7 +45,7 @@ WORKDIR /app
 COPY --from=builder /app/target/*.jar app.jar
 
 # Change ownership to non-root user
-RUN chown -R appuser:appgroup /app
+RUN chown -R "${UID}:${GID}" /app
 
 # Switch to non-root user
 USER appuser
@@ -50,7 +55,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
 
 # Run the application
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-mastery-multitrack/02-language-quickstart/java/docker-compose.yml
+++ b/docker-mastery-multitrack/02-language-quickstart/java/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - SERVER_PORT=8080
       - MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=health,info,metrics
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/docker-mastery-multitrack/02-language-quickstart/java/java-quickstart.md
+++ b/docker-mastery-multitrack/02-language-quickstart/java/java-quickstart.md
@@ -4,11 +4,11 @@
 
 Welcome to the Java track! In this module, you'll build a real Spring Boot application and containerize it, learning Docker concepts through practical Java development.
 
-## 🎯 Learning Objectives
+## 🎯 Learning Outcomes
 
 By completing this module, you will be able to:
 
-- ✅ Create a Spring Boot REST API from scratch
+- ✅ Navigate a real Spring Boot Task API in this repository (Docker lesson first)
 - ✅ Build and test REST endpoints using Spring Boot
 - ✅ **Containerize** a Java application with Docker
 - ✅ Understand **port mapping** and container networking
@@ -16,7 +16,7 @@ By completing this module, you will be able to:
 - ✅ Use **environment variables** for configuration
 - ✅ Debug issues with **logs and container inspection**
 
-## 📚 What You'll Build
+## 🚀 Project Overview
 
 A **Task Management REST API** with Docker integration:
 
@@ -36,7 +36,7 @@ A **Task Management REST API** with Docker integration:
 - Environment-based configuration
 - Non-root user security
 
-## ⏱️ Time Investment
+### ⏱️ Time Investment
 
 - **Understanding the App**: 15 minutes
 - **Building & Testing**: 20 minutes
@@ -44,46 +44,51 @@ A **Task Management REST API** with Docker integration:
 - **Docker Exploration**: 15 minutes
 - **Total**: ~1 hour
 
-## 📋 Prerequisites
+## 📦 Project Setup
 
 - ✅ Completed [Module 00: Prerequisites](../../00-prerequisites/) with Java track
 - ✅ Completed [Module 01: Docker Fundamentals](../../01-docker-fundamentals/)
 - ✅ Java 17+ and Maven installed
 - ✅ Basic Java knowledge (classes, methods, annotations)
 
-## 🏗️ Project Structure
+### 🏗️ Project Structure
+
+The Java track in this repository is already implemented under `com.example.dockerdemo`. Use the tree below to find source files; snippets match what is checked in.
 
 ```
 java/
-├── pom.xml                           # Maven configuration
-├── Dockerfile                       # Container definition
+├── pom.xml
+├── Dockerfile
+├── docker-compose.yml
 ├── src/
 │   ├── main/
-│   │   ├── java/com/example/taskapi/
-│   │   │   ├── TaskApiApplication.java     # Main class
+│   │   ├── java/com/example/dockerdemo/
+│   │   │   ├── DockerDemoApplication.java
 │   │   │   ├── controller/
-│   │   │   │   ├── HealthController.java   # Health endpoint
-│   │   │   │   └── TaskController.java     # REST API
+│   │   │   │   ├── HomeController.java      # GET /
+│   │   │   │   └── TaskController.java      # /api/tasks
 │   │   │   ├── model/
-│   │   │   │   └── Task.java               # Data model
+│   │   │   │   └── Task.java                # Lombok model
 │   │   │   └── service/
-│   │   │       └── TaskService.java        # Business logic
+│   │   │       └── TaskService.java
 │   │   └── resources/
-│   │       └── application.properties      # Configuration
-│   └── test/                               # Test classes
-└── .dockerignore                           # Docker ignore file
+│   │       └── application.properties
+│   └── test/
+└── .dockerignore
 ```
 
-## 🚀 Step 1: Create the Spring Boot Application
+## ☕ Java Implementation
 
-### Maven Configuration (pom.xml)
+You do **not** need to retype the application from scratch for the Docker lesson. Open the files above in your editor, or refer to the excerpts below (they mirror the repository).
+
+### Maven Configuration (`pom.xml`)
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -94,37 +99,38 @@ java/
     </parent>
 
     <groupId>com.example</groupId>
-    <artifactId>task-api</artifactId>
-    <version>1.0.0</version>
-    <name>Task Management API</name>
-    <description>Docker Learning Path - Java Track Example</description>
+    <artifactId>docker-demo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>docker-demo</name>
+    <description>Demo Spring Boot project for Docker learning</description>
 
     <properties>
         <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
-        <!-- Spring Boot Web -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
-        <!-- Spring Boot Actuator for health checks -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
-
-        <!-- Development tools -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
-
-        <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -137,60 +143,89 @@ java/
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>
 </project>
 ```
 
-### Application Configuration (application.properties)
+### Application Configuration (`application.properties`)
 
 ```properties
-# Server configuration
+# Application Configuration
+spring.application.name=docker-demo
 server.port=8080
-server.servlet.context-path=/api
 
-# Actuator configuration (for health checks)
-management.endpoints.web.exposure.include=health,info
+# Actuator Configuration
+management.endpoints.web.exposure.include=health,info,metrics,env
 management.endpoint.health.show-details=always
-management.endpoints.web.base-path=/
+management.info.env.enabled=true
 
-# Application information
-info.app.name=Task Management API
-info.app.description=Docker Learning Path Example
-info.app.version=1.0.0
+# Application Info
+info.app.name=Docker Demo API
+info.app.description=Spring Boot REST API for Docker learning
+info.app.version=0.0.1
+info.app.java.version=@java.version@
+
+# Logging
+logging.level.root=INFO
+logging.level.com.example.dockerdemo=DEBUG
+logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} - %msg%n
+
+# Jackson Configuration
+spring.jackson.serialization.write-dates-as-timestamps=false
+spring.jackson.serialization.indent-output=true
+
+# DevTools (will be disabled in production)
+spring.devtools.restart.enabled=true
+spring.devtools.livereload.enabled=true
 ```
 
-## 🔧 Step 2: Build the Application Code
+Actuator exposes health at `/actuator/health` by default (no need to set `management.endpoints.web.base-path` unless you customize it).
 
-### Main Application Class
+### 🔧 Application source (reference)
 
-Create `src/main/java/com/example/taskapi/TaskApiApplication.java`:
+#### `DockerDemoApplication.java`
 
 ```java
-package com.example.taskapi;
+package com.example.dockerdemo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class TaskApiApplication {
+public class DockerDemoApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(TaskApiApplication.class, args);
+        SpringApplication.run(DockerDemoApplication.class, args);
     }
 }
 ```
 
-### Task Model
-
-Create `src/main/java/com/example/taskapi/model/Task.java`:
+#### `Task.java` (Lombok)
 
 ```java
-package com.example.taskapi.model;
+package com.example.dockerdemo.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Task {
     private Long id;
     private String title;
@@ -198,72 +233,34 @@ public class Task {
     private boolean completed;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-
-    // Constructors
-    public Task() {
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    public Task(String title, String description) {
-        this();
-        this.title = title;
-        this.description = description;
-        this.completed = false;
-    }
-
-    // Getters and setters
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
-
-    public String getTitle() { return title; }
-    public void setTitle(String title) {
-        this.title = title;
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    public String getDescription() { return description; }
-    public void setDescription(String description) {
-        this.description = description;
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    public boolean isCompleted() { return completed; }
-    public void setCompleted(boolean completed) {
-        this.completed = completed;
-        this.updatedAt = LocalDateTime.now();
-    }
-
-    public LocalDateTime getCreatedAt() { return createdAt; }
-    public LocalDateTime getUpdatedAt() { return updatedAt; }
 }
 ```
 
-### Task Service
-
-Create `src/main/java/com/example/taskapi/service/TaskService.java`:
+#### `TaskService.java`
 
 ```java
-package com.example.taskapi.service;
+package com.example.dockerdemo.service;
 
-import com.example.taskapi.model.Task;
+import com.example.dockerdemo.model.Task;
 import org.springframework.stereotype.Service;
 
-import java.util.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Service
 public class TaskService {
 
-    private final Map<Long, Task> tasks = new ConcurrentHashMap<>();
-    private final AtomicLong nextId = new AtomicLong(1);
+    private final ConcurrentHashMap<Long, Task> tasks = new ConcurrentHashMap<>();
+    private final AtomicLong idCounter = new AtomicLong();
 
     public TaskService() {
-        // Add some sample data
-        createTask("Learn Docker fundamentals", "Complete Module 01 exercises");
-        createTask("Build first container", "Containerize this Java application");
-        createTask("Explore Docker Compose", "Learn multi-container applications");
+        createTask("Learn Docker", "Understand containerization basics");
+        createTask("Setup Spring Boot", "Create REST API with Spring Boot");
+        createTask("Connect to Database", "Learn Docker Compose with MariaDB");
     }
 
     public List<Task> getAllTasks() {
@@ -275,21 +272,27 @@ public class TaskService {
     }
 
     public Task createTask(String title, String description) {
-        Task task = new Task(title, description);
-        task.setId(nextId.getAndIncrement());
+        Task task = Task.builder()
+                .id(idCounter.incrementAndGet())
+                .title(title)
+                .description(description)
+                .completed(false)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
         tasks.put(task.getId(), task);
         return task;
     }
 
-    public Optional<Task> updateTask(Long id, Task updatedTask) {
-        Task existingTask = tasks.get(id);
-        if (existingTask != null) {
-            existingTask.setTitle(updatedTask.getTitle());
-            existingTask.setDescription(updatedTask.getDescription());
-            existingTask.setCompleted(updatedTask.isCompleted());
-            return Optional.of(existingTask);
-        }
-        return Optional.empty();
+    public Optional<Task> updateTask(Long id, Task taskUpdate) {
+        return Optional.ofNullable(tasks.computeIfPresent(id, (key, existingTask) -> {
+            existingTask.setTitle(taskUpdate.getTitle());
+            existingTask.setDescription(taskUpdate.getDescription());
+            existingTask.setCompleted(taskUpdate.isCompleted());
+            existingTask.setUpdatedAt(LocalDateTime.now());
+            return existingTask;
+        }));
     }
 
     public boolean deleteTask(Long id) {
@@ -302,15 +305,15 @@ public class TaskService {
 }
 ```
 
-### REST Controller
-
-Create `src/main/java/com/example/taskapi/controller/TaskController.java`:
+#### `TaskController.java`
 
 ```java
-package com.example.taskapi.controller;
+package com.example.dockerdemo.controller;
 
-import com.example.taskapi.model.Task;
-import com.example.taskapi.service.TaskService;
+import com.example.dockerdemo.model.Task;
+import com.example.dockerdemo.service.TaskService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -319,13 +322,11 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/api/tasks")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*")
 public class TaskController {
 
     private final TaskService taskService;
-
-    public TaskController(TaskService taskService) {
-        this.taskService = taskService;
-    }
 
     @GetMapping
     public List<Task> getAllTasks() {
@@ -340,10 +341,9 @@ public class TaskController {
     }
 
     @PostMapping
-    public Task createTask(@RequestBody Map<String, String> request) {
-        String title = request.get("title");
-        String description = request.get("description");
-        return taskService.createTask(title, description);
+    public ResponseEntity<Task> createTask(@RequestBody Task task) {
+        Task createdTask = taskService.createTask(task.getTitle(), task.getDescription());
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdTask);
     }
 
     @PutMapping("/{id}")
@@ -356,50 +356,54 @@ public class TaskController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
         if (taskService.deleteTask(id)) {
-            return ResponseEntity.ok().build();
+            return ResponseEntity.noContent().build();
         }
         return ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<Map<String, Long>> getTaskCount() {
+        return ResponseEntity.ok(Map.of("count", taskService.getTaskCount()));
     }
 }
 ```
 
-### Health Controller
-
-Create `src/main/java/com/example/taskapi/controller/HealthController.java`:
+#### `HomeController.java` (root JSON and endpoint hints)
 
 ```java
-package com.example.taskapi.controller;
+package com.example.dockerdemo.controller;
 
-import com.example.taskapi.service.TaskService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @RestController
-public class HealthController {
+public class HomeController {
 
-    private final TaskService taskService;
-
-    public HealthController(TaskService taskService) {
-        this.taskService = taskService;
-    }
+    @Value("${spring.application.name:docker-demo}")
+    private String applicationName;
 
     @GetMapping("/")
     public Map<String, Object> home() {
         return Map.of(
-            "message", "Task Management API is running!",
-            "version", "1.0.0",
+            "message", "Welcome to Docker Demo API!",
+            "application", applicationName,
+            "version", "0.0.1",
+            "timestamp", LocalDateTime.now(),
             "endpoints", Map.of(
                 "tasks", "/api/tasks",
-                "health", "/health"
+                "health", "/actuator/health",
+                "info", "/actuator/info"
             )
         );
     }
 }
 ```
 
-## 🧪 Step 3: Test the Application
+## 🧪 Testing Your Java Container
 
 ### Build and Run Locally
 
@@ -427,11 +431,11 @@ curl -X POST http://localhost:8080/api/tasks \
   -H "Content-Type: application/json" \
   -d '{"title": "Test Docker", "description": "Learn containerization"}'
 
-# Check health
-curl http://localhost:8080/health
+# Check health (Spring Boot Actuator endpoint)
+curl http://localhost:8080/actuator/health
 ```
 
-## 🐳 Step 4: Containerize with Docker
+## 🐳 Java Docker Patterns
 
 ### Create Dockerfile
 
@@ -490,7 +494,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-  CMD curl -f http://localhost:8080/health || exit 1
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
 
 # Run the application
 ENTRYPOINT ["java", "-jar", "app.jar"]
@@ -535,35 +539,41 @@ curl http://localhost:8080/api/tasks
 Use the included `docker-compose.yml` if you prefer a one-command run flow:
 
 ```bash
-# Start the Java quickstart service
-UID=$(id -u) GID=$(id -g) docker compose up -d
+# Start the Java quickstart service (optional: map host UID/GID for permission experiments)
+docker compose up -d
+# If you need host UID/GID and the image supports it:
+# UID=$(id -u) GID=$(id -g) docker compose up -d
 
 # Check service health
 docker compose ps
-curl http://localhost:8080/health
+curl http://localhost:8080/actuator/health
 
 # Stop and clean up
 docker compose down
 ```
 
-> Note: In this module, Java Compose intentionally builds from the production `Dockerfile` instead of a separate `Dockerfile.dev`. This keeps the quickstart simple and focused on baseline container behavior before development-workflow variants in later modules.
+> **Host UID/GID**: On some hosts (for example macOS), your `GID` may already exist inside the image build and cause `groupadd`/`addgroup` to fail during image build. If that happens, run `docker compose up` without passing `UID`/`GID`, or use the default build args in `docker-compose.yml`.
 
-## 🔍 Step 5: Docker Exploration
+> Note: In this module, Java Compose intentionally builds from the production `Dockerfile` instead of a separate `Dockerfile.dev`. This keeps the quickstart simple and focused on baseline container behavior before development-workflow variants in later modules. Spring Boot provides health checks through Actuator at `/actuator/health`.
+
+## 🔧 Java-Specific Docker Optimizations
 
 ### Container Inspection
 
 ```bash
-# View container logs
-docker logs task-api
+# View container logs (name depends how you started the container)
+docker logs task-api          # if you used: docker run --name task-api ...
+docker logs task-api-java    # if you used: docker compose up (see docker-compose.yml container_name)
 
 # Execute commands inside the container
 docker exec -it task-api bash
+# or: docker exec -it task-api-java bash
 
 # Inside the container, explore:
 ps aux                    # See running processes
 ls -la /app              # Check application files
 whoami                   # Verify non-root user
-curl localhost:8080/health  # Test from inside
+curl localhost:8080/actuator/health  # Test from inside
 ```
 
 ### Image Analysis
@@ -579,9 +589,9 @@ docker history task-api-java
 docker images eclipse-temurin:17-jre
 ```
 
-## 🎓 Knowledge Check
+## 🐛 Java Container Troubleshooting
 
-Test your understanding:
+Use these quick checks if the Java container does not behave as expected:
 
 1. **Why do we use multi-stage builds for Java applications?**
    <details>
@@ -598,21 +608,29 @@ Test your understanding:
 3. **How does the health check work in this container?**
    <details>
    <summary>Answer</summary>
-   Docker periodically calls `curl -f http://localhost:8080/health` inside the container. If it fails 3 times, the container is marked unhealthy.
+   Docker periodically calls `curl -f http://localhost:8080/actuator/health` inside the container. If it fails 3 times, the container is marked unhealthy.
    </details>
 
 ## 🧹 Cleanup
 
-```bash
-# Stop and remove the container
-docker stop task-api
-docker rm task-api
+### Standalone `docker run`
 
-# Remove the image (optional)
-docker rmi task-api-java
+```bash
+docker stop task-api 2>/dev/null || true
+docker rm task-api 2>/dev/null || true
+docker rmi task-api-java 2>/dev/null || true
 ```
 
-## 🚀 Going Further
+### Docker Compose
+
+From the `java/` directory:
+
+```bash
+docker compose down --remove-orphans
+docker rmi task-api-java 2>/dev/null || true
+```
+
+## 🚀 Next Steps
 
 ### Environment Variables
 
@@ -649,17 +667,16 @@ docker run -d -p 8080:8080 \
   task-api-java
 ```
 
-## 📋 Summary
+## ✅ Java Quickstart Checklist
 
-**You've successfully:**
+- [ ] Spring Boot Task API running in a container
+- [ ] Non-root user security implemented
+- [ ] Health checks working through `/actuator/health`
+- [ ] Multi-stage Java Docker build understood
+- [ ] Compose workflow tested for quick local startup
+- [ ] Container inspection and debugging commands practiced
 
-✅ Built a real Spring Boot REST API  
-✅ Created a secure, optimized Docker container  
-✅ Implemented health checks and non-root security  
-✅ Learned container inspection and debugging  
-✅ Understood multi-stage builds for Java
-
-**Next Step**: [Module 03: Dockerfile Essentials](../../03-dockerfile-essentials/) to master Docker image creation techniques!
+**Next steps**: [Module 03: Dockerfile Essentials](../../03-dockerfile-essentials/), then [Module 04: Docker Compose](../04-docker-compose/).
 
 ---
 

--- a/docker-mastery-multitrack/02-language-quickstart/python/Dockerfile
+++ b/docker-mastery-multitrack/02-language-quickstart/python/Dockerfile
@@ -15,8 +15,14 @@ RUN apt-get update && apt-get install -y \
 # Default to 1000 but allow override for different systems
 ARG UID=1000
 ARG GID=1000
-RUN groupadd -r -g ${GID} fastapi && \
-    useradd -r -g fastapi -u ${UID} fastapi
+RUN set -eux; \
+    if getent group "${GID}" >/dev/null 2>&1; then \
+      EXISTING="$(getent group "${GID}" | cut -d: -f1)"; \
+      useradd -r -g "${EXISTING}" -u "${UID}" fastapi; \
+    else \
+      groupadd -r -g "${GID}" fastapi; \
+      useradd -r -g fastapi -u "${UID}" fastapi; \
+    fi
 
 # Create app directory
 WORKDIR /app
@@ -35,7 +41,7 @@ RUN pip install uv || echo "UV unavailable, falling back to pip" && \
     fi
 
 # Copy application code
-COPY --chown=fastapi:fastapi src/ ./src/
+COPY --chown=${UID}:${GID} src/ ./src/
 
 # Switch to non-root user
 USER fastapi:fastapi

--- a/docker-mastery-multitrack/02-language-quickstart/python/Dockerfile.dev
+++ b/docker-mastery-multitrack/02-language-quickstart/python/Dockerfile.dev
@@ -14,8 +14,14 @@ RUN apt-get update && apt-get install -y \
 # Create non-root user with configurable UID/GID
 ARG UID=1000
 ARG GID=1000
-RUN groupadd -r -g ${GID} fastapi && \
-    useradd -r -g fastapi -u ${UID} fastapi
+RUN set -eux; \
+    if getent group "${GID}" >/dev/null 2>&1; then \
+      EXISTING="$(getent group "${GID}" | cut -d: -f1)"; \
+      useradd -r -g "${EXISTING}" -u "${UID}" fastapi; \
+    else \
+      groupadd -r -g "${GID}" fastapi; \
+      useradd -r -g fastapi -u "${UID}" fastapi; \
+    fi
 
 WORKDIR /app
 

--- a/docker-mastery-multitrack/02-language-quickstart/python/python-quickstart.md
+++ b/docker-mastery-multitrack/02-language-quickstart/python/python-quickstart.md
@@ -366,7 +366,10 @@ CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8080"]
 
 ### Development Dockerfile
 
+Matches `Dockerfile.dev` in this folder (includes `UID`/`GID` build args used by Compose).
+
 ```dockerfile
+# Development Dockerfile for Python Task API
 FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -379,23 +382,34 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd -r fastapi && useradd -r -g fastapi -u 1000 fastapi
+# Create non-root user with configurable UID/GID
+ARG UID=1000
+ARG GID=1000
+RUN set -eux; \
+    if getent group "${GID}" >/dev/null 2>&1; then \
+      EXISTING="$(getent group "${GID}" | cut -d: -f1)"; \
+      useradd -r -g "${EXISTING}" -u "${UID}" fastapi; \
+    else \
+      groupadd -r -g "${GID}" fastapi; \
+      useradd -r -g fastapi -u "${UID}" fastapi; \
+    fi
 
 WORKDIR /app
 
-# Install dependencies with development packages
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Install dependencies - UV first (modern), pip fallback
+COPY pyproject.toml requirements.txt ./
 
-# Additional development dependencies
-RUN pip install --no-cache-dir \
-    pytest \
-    pytest-asyncio \
-    httpx \
-    black \
-    isort \
-    flake8
+# Install UV and dependencies with dev packages
+RUN pip install uv || echo "UV unavailable, falling back to pip" && \
+    if command -v uv >/dev/null 2>&1; then \
+        echo "📦 Using UV with dev dependencies" && \
+        uv pip install --system --no-cache -r requirements.txt && \
+        uv pip install --system --no-cache pytest pytest-asyncio httpx black isort flake8; \
+    else \
+        echo "📦 Using pip with manual dev dependencies" && \
+        pip install --no-cache-dir -r requirements.txt && \
+        pip install --no-cache-dir pytest pytest-asyncio httpx black isort flake8; \
+    fi
 
 # Switch to non-root user
 USER fastapi:fastapi
@@ -414,13 +428,19 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     volumes:
       # Hot reload source code
-      - ./src:/app/src:ro
+      - ./src:/app/src:cached
+      # Named volume for cache (no permission issues)
+      - python-cache:/app/.cache
     ports:
       - "8080:8080"
     environment:
       - ENV=development
+      - LOG_LEVEL=DEBUG
     networks:
       - dev-network
 
@@ -435,6 +455,9 @@ services:
   #     - "5432:5432"
   #   networks:
   #     - dev-network
+
+volumes:
+  python-cache:
 
 networks:
   dev-network:
@@ -459,6 +482,8 @@ RUN if command -v uv >/dev/null 2>&1; then \
 ```
 
 ### Multi-Stage Build for Production
+
+Abbreviated pattern; see `Dockerfile` in this folder for UV/pip install and **UID/GID-safe** `COPY --chown=${UID}:${GID}`.
 
 ```dockerfile
 # Build stage
@@ -532,6 +557,8 @@ UID=$(id -u) GID=$(id -g) docker compose up
 ```
 
 **For production**: Use named volumes instead of bind mounts to avoid permission issues entirely.
+
+The production and development Dockerfiles in this folder **reuse an existing `GID` inside the image when it already exists**, so typical `docker compose up` flows are less likely to fail on hosts like macOS.
 
 📖 **See**: [Complete Volumes & Permissions Guide](../../common-resources/VOLUMES_AND_PERMISSIONS_GUIDE.md) for details.
 
@@ -634,6 +661,32 @@ docker exec python-api ps aux
 docker exec python-api curl http://localhost:8080/health
 ```
 
+## 🧹 Cleanup
+
+### Standalone `docker run`
+
+```bash
+docker stop python-api 2>/dev/null || true
+docker rm python-api 2>/dev/null || true
+docker rmi task-api-python 2>/dev/null || true
+```
+
+### Docker Compose
+
+From the `python/` directory:
+
+```bash
+docker compose down --remove-orphans
+docker rmi task-api-python 2>/dev/null || true
+```
+
+Optional: remove the named cache volume:
+
+```bash
+docker volume ls | grep python-cache
+# docker volume rm <project>_python-cache
+```
+
 ## ✅ Python Quickstart Checklist
 
 Congratulations! You've mastered Python containerization:
@@ -648,6 +701,6 @@ Congratulations! You've mastered Python containerization:
 
 ## 🚀 Next Steps
 
-Ready for multi-container applications? Continue to [Module 04: Docker Compose](../04-docker-compose/) where you'll add PostgreSQL and build a complete stack!
+Go deeper on image design in [Module 03: Dockerfile Essentials](../../03-dockerfile-essentials/), then wire services together in [Module 04: Docker Compose](../04-docker-compose/).
 
 **Remember**: These Python Docker patterns work for ANY Python application - Django, Flask, Tornado. Master the concepts here and apply them everywhere!

--- a/docker-mastery-multitrack/02-language-quickstart/rust/Dockerfile
+++ b/docker-mastery-multitrack/02-language-quickstart/rust/Dockerfile
@@ -32,14 +32,21 @@ RUN apk add --no-cache ca-certificates curl
 # Create non-root user with configurable UID/GID
 ARG UID=1000
 ARG GID=1000
-RUN addgroup -g ${GID} rust && adduser -D -s /bin/sh -u ${UID} -G rust rust
+RUN set -eux; \
+    if getent group "${GID}" >/dev/null 2>&1; then \
+      GEXIST="$(getent group "${GID}" | cut -d: -f1)"; \
+      adduser -D -s /bin/sh -u "${UID}" -G "${GEXIST}" rust; \
+    else \
+      addgroup -g "${GID}" rust; \
+      adduser -D -s /bin/sh -u "${UID}" -G rust rust; \
+    fi
 
 # Create app directory
 WORKDIR /app
-RUN chown rust:rust /app
+RUN chown "${UID}:${GID}" /app
 
 # Copy binary from builder stage
-COPY --from=builder --chown=rust:rust /usr/src/app/target/release/task-api .
+COPY --from=builder --chown=${UID}:${GID} /usr/src/app/target/release/task-api .
 
 # Switch to non-root user
 USER rust:rust

--- a/docker-mastery-multitrack/02-language-quickstart/rust/Dockerfile.dev
+++ b/docker-mastery-multitrack/02-language-quickstart/rust/Dockerfile.dev
@@ -8,14 +8,21 @@ RUN cargo install cargo-watch
 # Create non-root user
 ARG UID=1000
 ARG GID=1000
-RUN addgroup -g ${GID} rust && adduser -D -s /bin/sh -u ${UID} -G rust rust
+RUN set -eux; \
+    if getent group "${GID}" >/dev/null 2>&1; then \
+      GEXIST="$(getent group "${GID}" | cut -d: -f1)"; \
+      adduser -D -s /bin/sh -u "${UID}" -G "${GEXIST}" rust; \
+    else \
+      addgroup -g "${GID}" rust; \
+      adduser -D -s /bin/sh -u "${UID}" -G rust rust; \
+    fi
 
 WORKDIR /app
-RUN chown rust:rust /app
+RUN chown "${UID}:${GID}" /app
 
 # Fix cargo registry permissions before switching user
 RUN mkdir -p /usr/local/cargo/registry && \
-    chown -R rust:rust /usr/local/cargo
+    chown -R "${UID}:${GID}" /usr/local/cargo
 
 USER rust:rust
 

--- a/docker-mastery-multitrack/02-language-quickstart/rust/rust-quickstart.md
+++ b/docker-mastery-multitrack/02-language-quickstart/rust/rust-quickstart.md
@@ -477,59 +477,71 @@ id -u
 # Enterprise Linux: often 10000+
 ```
 
-**If you plan to use bind mounts**, build with your actual UID:
+**If you plan to use bind mounts** (mounting host directories), build with your actual UID:
 
 ```bash
 # Build with your host UID/GID to avoid permission issues
 docker build --build-arg UID=$(id -u) --build-arg GID=$(id -g) -t task-api-rust .
 ```
 
+The Dockerfiles in this folder reuse an existing image `GID` when it already exists, which avoids common failures on hosts like macOS when passing through host `GID`.
+
 📖 **See**: [Complete Volumes & Permissions Guide](../../common-resources/VOLUMES_AND_PERMISSIONS_GUIDE.md) for details.
 
 ## 🐳 Rust Docker Patterns
 
-### Production Dockerfile (Multi-stage)
+### Production Dockerfile (matches `Dockerfile`)
 
 ```dockerfile
+# Production Dockerfile for Rust Task API
+# Multi-stage build for minimal image size
+
 # Build stage
-FROM rust:1.75 as builder
+FROM rust:alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache musl-dev
 
 WORKDIR /usr/src/app
 
-# Copy manifests
+# Copy dependency files first for better caching
 COPY Cargo.toml Cargo.lock ./
 
-# Create dummy source to build dependencies
+# Create dummy source to cache dependencies
 RUN mkdir src && echo "fn main() {}" > src/main.rs
-
-# Build dependencies (cached layer)
 RUN cargo build --release
-RUN rm src/main.rs
+RUN rm -rf src
 
-# Copy source code
+# Copy real source code
 COPY src ./src
 
 # Build application
 RUN cargo build --release
 
-# Runtime stage - minimal Debian
-FROM debian:bookworm-slim
+# Runtime stage
+FROM alpine:3.18
 
-# Install minimal runtime dependencies
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates curl
 
-# Create non-root user
-RUN groupadd -r rust && useradd -r -g rust -u 1000 rust
+# Create non-root user with configurable UID/GID
+ARG UID=1000
+ARG GID=1000
+RUN set -eux; \
+    if getent group "${GID}" >/dev/null 2>&1; then \
+      GEXIST="$(getent group "${GID}" | cut -d: -f1)"; \
+      adduser -D -s /bin/sh -u "${UID}" -G "${GEXIST}" rust; \
+    else \
+      addgroup -g "${GID}" rust; \
+      adduser -D -s /bin/sh -u "${UID}" -G rust rust; \
+    fi
 
 # Create app directory
 WORKDIR /app
-RUN chown rust:rust /app
+RUN chown "${UID}:${GID}" /app
 
 # Copy binary from builder stage
-COPY --from=builder --chown=rust:rust /usr/src/app/target/release/task-api .
+COPY --from=builder --chown=${UID}:${GID} /usr/src/app/target/release/task-api .
 
 # Switch to non-root user
 USER rust:rust
@@ -545,62 +557,46 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
 CMD ["./task-api"]
 ```
 
-### Minimal Dockerfile (Distroless)
+### Conceptual: distroless and `scratch` runtimes (not in this folder)
+
+The runnable quickstart uses **Alpine** in both build and runtime stages. Smaller runtimes such as **distroless** or **`FROM scratch`** are common in real projects, but this module does not ship separate `Dockerfile.distroless` or `Dockerfile.scratch` files. Treat the patterns below as **reading material**, not copy-paste build files.
+
+<details>
+<summary>Example: distroless-style layout (conceptual)</summary>
 
 ```dockerfile
-# Build stage
-FROM rust:1.75 as builder
-
+# CONCEPTUAL ONLY — not a file in this repository
+FROM rust:1.75 AS builder
 WORKDIR /usr/src/app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-
-# Build static binary
 ENV RUSTFLAGS="-C target-feature=+crt-static"
 RUN cargo build --release --target x86_64-unknown-linux-gnu
-
-# Runtime stage - Google's distroless
 FROM gcr.io/distroless/static-debian12
-
-# Copy binary
 COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-gnu/release/task-api /
-
-# Distroless runs as non-root by default
-EXPOSE 8080
-
-# Note: No health check in distroless (no shell)
 ENTRYPOINT ["/task-api"]
 ```
 
-### Scratch-based Dockerfile (Ultra-minimal)
+</details>
+
+<details>
+<summary>Example: scratch layout (conceptual)</summary>
 
 ```dockerfile
-# Build stage
-FROM rust:1.75 as builder
-
+# CONCEPTUAL ONLY — not a file in this repository
+FROM rust:1.75 AS builder
 WORKDIR /usr/src/app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-
-# Build fully static binary
 ENV RUSTFLAGS="-C target-feature=+crt-static"
 RUN cargo build --release --target x86_64-unknown-linux-musl
-
-# Runtime stage - scratch (empty)
 FROM scratch
-
-# Copy CA certificates for HTTPS
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
-# Copy binary
 COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-musl/release/task-api /task-api
-
-# Expose port
-EXPOSE 8080
-
-# Run application
 ENTRYPOINT ["/task-api"]
 ```
+
+</details>
 
 ### Docker Compose Development
 
@@ -610,10 +606,15 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+      args:
+        UID: ${UID:-1000}
+        GID: ${GID:-1000}
     volumes:
       # Hot reload source code
-      - ./src:/usr/src/app/src:ro
-      - ./Cargo.toml:/usr/src/app/Cargo.toml:ro
+      - ./src:/app/src:cached
+      - ./Cargo.toml:/app/Cargo.toml:ro
+      # Cargo cache for faster builds
+      - cargo-cache:/usr/local/cargo/registry
     ports:
       - "8080:8080"
     environment:
@@ -622,34 +623,52 @@ services:
     networks:
       - dev-network
 
+volumes:
+  cargo-cache:
+
 networks:
   dev-network:
 ```
 
 ## 🔧 Rust-Specific Optimizations
 
-### Build Performance
+### Build Performance (`Dockerfile.dev`)
+
+This matches the development image used by `docker compose` in this folder (`rust:alpine`, `WORKDIR /app`, `cargo-watch`).
 
 ```dockerfile
-# Dockerfile.dev - Development with faster builds
-FROM rust:1.75
+# Development Dockerfile for Rust Task API
+FROM rust:alpine
 
-WORKDIR /usr/src/app
-
-# Install cargo-watch for hot reload
+# Install development tools
+RUN apk add --no-cache musl-dev curl
 RUN cargo install cargo-watch
 
-# Copy manifests
-COPY Cargo.toml Cargo.lock ./
+# Create non-root user
+ARG UID=1000
+ARG GID=1000
+RUN set -eux; \
+    if getent group "${GID}" >/dev/null 2>&1; then \
+      GEXIST="$(getent group "${GID}" | cut -d: -f1)"; \
+      adduser -D -s /bin/sh -u "${UID}" -G "${GEXIST}" rust; \
+    else \
+      addgroup -g "${GID}" rust; \
+      adduser -D -s /bin/sh -u "${UID}" -G rust rust; \
+    fi
 
-# Pre-build dependencies
-RUN mkdir src && echo "fn main() {}" > src/main.rs
-RUN cargo build
-RUN rm src/main.rs
+WORKDIR /app
+RUN chown "${UID}:${GID}" /app
 
+# Fix cargo registry permissions before switching user
+RUN mkdir -p /usr/local/cargo/registry && \
+    chown -R "${UID}:${GID}" /usr/local/cargo
+
+USER rust:rust
+
+# Expose port
 EXPOSE 8080
 
-# Hot reload command
+# Development command with hot reload
 CMD ["cargo", "watch", "-x", "run"]
 ```
 
@@ -730,19 +749,15 @@ docker images | grep task-api-rust
 ab -n 10000 -c 100 http://localhost:8080/health
 ```
 
-### Image Size Comparison
+### Image size (this quickstart)
 
 ```bash
-# Compare different base images
-docker build -f Dockerfile -t rust-debian .
-docker build -f Dockerfile.distroless -t rust-distroless .
-docker build -f Dockerfile.scratch -t rust-scratch .
-
-docker images | grep rust-
-# rust-debian     ~100MB
-# rust-distroless ~20MB
-# rust-scratch    ~10MB
+# Production image for this module
+docker build -f Dockerfile -t task-api-rust .
+docker images task-api-rust
 ```
+
+Compare sizes with other projects after you experiment with distroless or scratch patterns in your own Dockerfiles.
 
 ## 🐛 Rust Container Troubleshooting
 
@@ -794,6 +809,32 @@ docker run -it --rm rust-api /bin/bash
 docker exec rust-api ps aux
 ```
 
+## 🧹 Cleanup
+
+### Standalone `docker run`
+
+```bash
+docker stop rust-api 2>/dev/null || true
+docker rm rust-api 2>/dev/null || true
+docker rmi task-api-rust 2>/dev/null || true
+```
+
+### Docker Compose
+
+From the `rust/` directory:
+
+```bash
+docker compose down --remove-orphans
+docker rmi task-api-rust 2>/dev/null || true
+```
+
+Optional: remove the named Cargo cache volume Compose created:
+
+```bash
+docker volume ls | grep cargo-cache
+# docker volume rm <project>_cargo-cache
+```
+
 ## ✅ Rust Quickstart Checklist
 
 Congratulations! You've mastered Rust containerization:
@@ -801,13 +842,13 @@ Congratulations! You've mastered Rust containerization:
 - [ ] Actix-web Task API running in container
 - [ ] Multi-stage builds for optimized images
 - [ ] Static binary compilation working
-- [ ] Minimal container images (distroless/scratch)
+- [ ] Minimal Alpine-based production image from this module’s `Dockerfile`
 - [ ] Non-root user security implemented
 - [ ] Prometheus metrics integrated
 - [ ] Can debug Rust-specific container issues
 
 ## 🚀 Next Steps
 
-Ready for multi-container applications? Continue to [Module 04: Docker Compose](../04-docker-compose/) where you'll add PostgreSQL and build a complete stack!
+Solidify image design and layer caching in [Module 03: Dockerfile Essentials](../../03-dockerfile-essentials/), then add databases and Compose in [Module 04: Docker Compose](../04-docker-compose/).
 
 **Remember**: Rust's compile-time guarantees and zero-cost abstractions make it perfect for containerized microservices. These patterns scale to any Rust application - web servers, CLI tools, system services!


### PR DESCRIPTION
- Java: document com.example.dockerdemo layout, use /actuator/health in Dockerfile, Compose healthcheck, and tutorial; clarify Compose vs standalone.
- Python/Rust: match Dockerfile snippets to repo files, document UID/GID and GID reuse in image builds, split cleanup for Compose vs standalone.
- Rust: keep distroless/scratch as conceptual notes; production block matches the checked-in multistage Dockerfile.